### PR TITLE
Display number of likes for each item on the Homepage

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -191,3 +191,14 @@ form>input,textarea{
 form>input:focus,textarea:focus{
   border:3px solid #06C4C7 ;
 }
+
+.likeBtn:hover{
+  color:yellow;
+  cursor:pointer;
+}
+.likeBtn-number{
+  display:flex;
+  align-items:center;
+  gap:5px;
+
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,13 +1,16 @@
 import '../css/index.css';
 import Popup from './modules/popup';
 import ShowDetails from './modules/api/showData.js';
+
+import getLikes from './modules/api/getLikes.js'
 const closeBtn = document.querySelector('.fa')
 const popWindow = document.querySelector('.popup-section');
 
 
 
-
 ShowDetails();
+
+
 
 
 

--- a/src/js/modules/api/getLikes.js
+++ b/src/js/modules/api/getLikes.js
@@ -1,0 +1,11 @@
+const getLikes = async() =>{
+    const likesUrl = `https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/5Ap1XN8WUsuZk6doKhi8/likes`;
+
+      const likesRequest = await fetch(likesUrl)
+     const likes = await  likesRequest.json();
+    return likes;
+
+
+}
+export default getLikes;
+

--- a/src/js/modules/api/postLikes.js
+++ b/src/js/modules/api/postLikes.js
@@ -1,0 +1,12 @@
+const postLikes = () => {
+    const likesUrl = `https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/5Ap1XN8WUsuZk6doKhi8/likes`;
+    const request =  await fetch(likesUrl, {
+        method: "POST",
+        body: JSON.stringify({
+            "item_id": 1,
+        }),
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+}

--- a/src/js/modules/api/showData.js
+++ b/src/js/modules/api/showData.js
@@ -1,35 +1,56 @@
 import Popup from "../popup.js";
+import getLikes from "./getLikes.js";
 
-const BaseUrl = 'https://api.tvmaze.com/shows';
+const BaseUrl = "https://api.tvmaze.com/shows";
 
 const ShowDetails = async () => {
-  const containersShows = document.querySelector('.container-movies');
+  const containersShows = document.querySelector(".container-movies");
   const shows = await fetch(BaseUrl);
   const result = await shows.json();
- 
+  const likesDta = await getLikes();
+  console.log(likesDta);
+
   for (let i = 0; i < 9 && i < result.length; i++) {
     const ShowList = `
     <img src="${result[i].image.original}" alt="">
    <div class="name-likes">
       <h3>${result[i].name}</h3>
-      <i class="fa fa-thumbs-up">likes</i>
+      <div class="likeBtn-number">
+      
+      <h3 class="like-part"></h3>
+      </div>
+      
    </div>
    <button class="commentBtn">Comments</button>`;
-   const card = document.createElement('div');
-   card.classList.add('show-card');
-   card.innerHTML = ShowList;
-   containersShows.appendChild(card);
+    const card = document.createElement("div");
+    card.classList.add("show-card");
+    card.innerHTML = ShowList;
+    containersShows.appendChild(card);
   }
   const pop = new Popup();
-  const commentBtns = document.querySelectorAll('.commentBtn');
-  commentBtns.forEach((buttonItem,index) => {
-    buttonItem.addEventListener('click' , () => {
-      const ida = index+1;
-     
- pop.popupDetails(ida);
-    })
-  }
-  )
+  const commentBtns = document.querySelectorAll(".commentBtn");
+  commentBtns.forEach((buttonItem, index) => {
+    buttonItem.addEventListener("click", () => {
+      const ida = index + 1;
+
+      pop.popupDetails(ida);
+    });
+  });
+
+const likeSelect = document.querySelectorAll('.like-part');
+const newLikes = likesDta.shift();
+console.log(likesDta)
+likesDta.forEach((likeItem,likeIndex) => {
+  likeSelect.forEach((selectItem,selectIndex) => {
+    if(likeIndex== selectIndex){
+      selectItem.textContent = `${likeItem.likes} likes`
+    }
+    else{
+      selectItem.textContent = `0 likes`
+    }
+  })
+})
+
 };
 
 export default ShowDetails;


### PR DESCRIPTION
When the page loads, the webapp the Involvement API to show the item likes and combines them with the data from the base API.

Remember that your page should make only 2 requests:

-   one to the base API
-   and one to the Involvement API.

This task does not include displaying the likes button (heart icon on the wireframe) for each item.